### PR TITLE
Add missing 'flink.version' variable

### DIFF
--- a/KafkaConnectors/pom.xml
+++ b/KafkaConnectors/pom.xml
@@ -13,6 +13,7 @@
     <java.version>1.8</java.version>
     <scala.binary.version>2.11</scala.binary.version>
     <kda.version>1.1.0</kda.version>
+    <flink.version>1.8.0</flink.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
It looks like `flink.version` was inadvertently removed in this commit https://github.com/aws-samples/amazon-kinesis-data-analytics-java-examples/commit/31e75410b56246f6aed52b50c67e77be8f38f4bf#diff-9e56bcd3df73fb999f363bfc8f89aed2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
