### PR TITLE
Updating Amazon Kinesis Connector Flink to v2.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+*/target/

--- a/EfoConsumer/pom.xml
+++ b/EfoConsumer/pom.xml
@@ -16,9 +16,8 @@
         <java.version>1.11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <flink-connector.version>1.8.2-EFO</flink-connector.version>
         <flink.version>1.11.1</flink.version>
-        <amazon-kinesis-connector-flink.version>2.0.0</amazon-kinesis-connector-flink.version>
+        <amazon-kinesis-connector-flink.version>2.0.3</amazon-kinesis-connector-flink.version>
         <main-class>software.amazon.kinesis.EfoApplication</main-class>
     </properties>
 

--- a/python/GettingStarted/application_properties.json
+++ b/python/GettingStarted/application_properties.json
@@ -3,7 +3,7 @@
   "PropertyGroupId": "kinesis.analytics.flink.run.options",
   "PropertyMap": {
     "python": "GettingStarted/getting-started.py",
-    "jarfile": "GettingStarted/lib/amazon-kinesis-connector-flink-2.0.0.jar"
+    "jarfile": "GettingStarted/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar"
    }
   },
   {

--- a/python/GettingStarted/getting-started.py
+++ b/python/GettingStarted/getting-started.py
@@ -34,7 +34,7 @@ if is_local:
     CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
     table_env.get_config().get_configuration().set_string(
         "pipeline.jars",
-        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-connector-flink-2.0.0.jar",
+        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar",
     )
 
 

--- a/python/S3Sink/application_properties.json
+++ b/python/S3Sink/application_properties.json
@@ -3,7 +3,7 @@
           "PropertyGroupId": "kinesis.analytics.flink.run.options",
           "PropertyMap": {
             "python": "StreamingFileSink/streaming-file-sink.py",
-            "jarfile": "StreamingFileSink/lib/amazon-kinesis-connector-flink-2.0.0.jar"
+            "jarfile": "StreamingFileSink/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar"
           }
         },
         {

--- a/python/S3Sink/streaming-file-sink.py
+++ b/python/S3Sink/streaming-file-sink.py
@@ -40,7 +40,7 @@ if is_local:
         "pipeline.jars",
         "file:///"
         + CURRENT_DIR
-        + "/lib/amazon-kinesis-connector-flink-2.0.0.jar;file:///"
+        + "/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar;file:///"
         + CURRENT_DIR
         + "/plugins/flink-s3-fs-hadoop/flink-s3-fs-hadoop-1.11.2.jar",
     )

--- a/python/SlidingWindow/application_properties.json
+++ b/python/SlidingWindow/application_properties.json
@@ -3,7 +3,7 @@
           "PropertyGroupId": "kinesis.analytics.flink.run.options",
           "PropertyMap": {
             "python": "SlidingWindows/sliding-windows.py",
-            "jarfile": "SlidingWindows/lib/amazon-kinesis-connector-flink-2.0.0.jar"
+            "jarfile": "SlidingWindows/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar"
           }
         },
         {

--- a/python/SlidingWindow/sliding-windows.py
+++ b/python/SlidingWindow/sliding-windows.py
@@ -37,7 +37,7 @@ if is_local:
     CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
     table_env.get_config().get_configuration().set_string(
         "pipeline.jars",
-        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-connector-flink-2.0.0.jar",
+        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar",
     )
 
 

--- a/python/TumblingWindow/application_properties.json
+++ b/python/TumblingWindow/application_properties.json
@@ -3,7 +3,7 @@
           "PropertyGroupId": "kinesis.analytics.flink.run.options",
           "PropertyMap": {
             "python": "TumblingWindows/tumbling-windows.py",
-            "jarfile": "TumblingWindows/lib/amazon-kinesis-connector-flink-2.0.0.jar"
+            "jarfile": "TumblingWindows/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar"
           }
         },
         {

--- a/python/TumblingWindow/tumbling-windows.py
+++ b/python/TumblingWindow/tumbling-windows.py
@@ -37,7 +37,7 @@ if is_local:
     CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
     table_env.get_config().get_configuration().set_string(
         "pipeline.jars",
-        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-connector-flink-2.0.0.jar",
+        "file:///" + CURRENT_DIR + "/lib/amazon-kinesis-sql-connector-flink-2.0.3.jar",
     )
 
 


### PR DESCRIPTION
*Description of changes:*
- Updating Amazon Kinesis Flink Connector to `v2.0.3` for EFO and Python samples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
