### PR TITLE
Amazon CloudWatch Metrics Async Sink example

### DIFF
--- a/cloudwatch-async-sink-example/README.md
+++ b/cloudwatch-async-sink-example/README.md
@@ -1,0 +1,12 @@
+# CloudWatch Metrics Async Sink Example
+
+This sample project demonstrates how to build a simple Sink using the Async Sink framework.
+
+The example application uses two dummy data generator sources and delivers metrics to Amazon CloudWatch Metrics. 
+Two hours of bulk data is generated when the job starts up, followed by one record per second per data source.
+
+## Flink Compatibility
+
+**Note:** This project is compatible with Apache Flink 1.15+. 
+This project is not compatible with Amazon Kinesis Data Analytics until Apache Flink 1.15 or highter is supported.
+

--- a/cloudwatch-async-sink-example/pom.xml
+++ b/cloudwatch-async-sink-example/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>software.amazon.flink.example</groupId>
+    <artifactId>cloudwatch-async-sink-example</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <flink.version>1.15.1</flink.version>
+        <lombok.version>1.18.24</lombok.version>
+        <aws.sdk.version>2.17.52</aws.sdk.version>
+        <logback.version>1.2.11</logback.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-aws-base</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-base</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatch</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/CloudwatchAsyncSinkExample.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/CloudwatchAsyncSinkExample.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example;
+
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.flink.example.model.OrderStats;
+import software.amazon.flink.example.sink.CloudWatchMetricsSink;
+import software.amazon.flink.example.source.SawToothSourceFunction;
+import software.amazon.flink.example.source.SineSourceFunction;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.flink.connector.aws.config.AWSConfigConstants.AWS_REGION;
+import static software.amazon.awssdk.regions.Region.US_EAST_1;
+
+public class CloudwatchAsyncSinkExample {
+
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        SineSourceFunction sports = new SineSourceFunction("sports");
+        SawToothSourceFunction clothing = new SawToothSourceFunction("clothing");
+
+        DataStreamSource<OrderStats> sportsStream = env.addSource(sports);
+        DataStreamSource<OrderStats> clothingStream = env.addSource(clothing);
+
+        Properties clientProperties = new Properties();
+        clientProperties.setProperty(AWS_REGION, US_EAST_1.id());
+
+        CloudWatchMetricsSink<OrderStats> cloudWatchMetricsSink = CloudWatchMetricsSink.<OrderStats>builder()
+                .clientProperties(clientProperties)
+                .namespace("cloudwatch-metrics-example")
+                .metricName("count")
+                .valueExtractor(OrderStats::getCount)
+                .timestampExtractor(OrderStats::getTimestamp)
+                .dimensionsExtractor(orderStats -> List.of(
+                        Dimension.builder()
+                                .name("category")
+                                .value(orderStats.getCategory())
+                                .build()))
+                .build();
+
+        sportsStream.union(clothingStream).sinkTo(cloudWatchMetricsSink);
+
+        env.execute("Cloudwatch Metrics Async Sink Example");
+    }
+
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/model/OrderStats.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/model/OrderStats.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@ToString
+public class OrderStats {
+
+    private final double count;
+    private final Instant timestamp;
+    private final String category;
+
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsElementConverter.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsElementConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.sink;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+
+import lombok.Builder;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Function;
+
+@Builder
+public class CloudWatchMetricsElementConverter<T> implements ElementConverter<T, MetricDatum> {
+
+    private final String metricName;
+    private final Function<T, Double> valueExtractor;
+    private final Function<T, Instant> timestampExtractor;
+    private final Function<T, List<Dimension>> dimensionExtractor;
+
+    @Override
+    public MetricDatum apply(T record, SinkWriter.Context context) {
+        return MetricDatum.builder()
+                .metricName(metricName)
+                .value(valueExtractor.apply(record))
+                .timestamp(timestampExtractor.apply(record))
+                .dimensions(dimensionExtractor.apply(record))
+                .build();
+    }
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsSink.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsSink.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.sink;
+
+import org.apache.flink.connector.base.sink.AsyncSinkBase;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import lombok.Builder;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Function;
+
+public class CloudWatchMetricsSink<T> extends AsyncSinkBase<T, MetricDatum> {
+
+    private final String namespace;
+    private final Properties clientProperties;
+
+    @Builder
+    public CloudWatchMetricsSink(
+            String namespace,
+            Properties clientProperties,
+            String metricName,
+            ValueExtractor<T> valueExtractor,
+            TimestampExtractor<T> timestampExtractor,
+            DimensionsExtractor<T> dimensionsExtractor) {
+        super(
+                CloudWatchMetricsElementConverter.<T>builder()
+                        .metricName(metricName)
+                        .valueExtractor(valueExtractor)
+                        .timestampExtractor(timestampExtractor)
+                        .dimensionExtractor(dimensionsExtractor)
+                        .build(),
+                1_000, // maxBatchSize
+                1, // maxInFlightRequests
+                10_000, // maxBufferedRequestEntries
+                40 * 1_024, // maxBatchSizeInBytes
+                10_000, // maxTimeInBufferMS
+                1_000); // maxRecordSizeInBytes
+        this.namespace = namespace;
+        this.clientProperties = clientProperties;
+    }
+
+    @Override
+    public StatefulSinkWriter<T, BufferedRequestState<MetricDatum>> createWriter(InitContext initContext) throws IOException {
+        return restoreWriter(initContext, Collections.emptyList());
+    }
+
+    @Override
+    public StatefulSinkWriter<T, BufferedRequestState<MetricDatum>> restoreWriter(InitContext initContext, Collection<BufferedRequestState<MetricDatum>> collection) throws IOException {
+        return new CloudWatchMetricsSinkWriter<>(
+                namespace,
+                clientProperties,
+                getElementConverter(),
+                initContext,
+                getMaxBatchSize(),
+                getMaxInFlightRequests(),
+                getMaxBufferedRequests(),
+                getMaxBatchSizeInBytes(),
+                getMaxTimeInBufferMS(),
+                getMaxRecordSizeInBytes(),
+                collection);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<BufferedRequestState<MetricDatum>> getWriterStateSerializer() {
+        return new CloudWatchMetricsStateSerializer();
+    }
+
+    public interface ValueExtractor<T> extends Function<T, Double>, Serializable {
+    }
+
+    public interface TimestampExtractor<T> extends Function<T, Instant>, Serializable {
+    }
+
+    public interface DimensionsExtractor<T> extends Function<T, List<Dimension>>, Serializable {
+    }
+
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsSinkWriter.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsSinkWriter.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.sink;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.aws.config.AWSConfigConstants;
+import org.apache.flink.connector.aws.util.AWSAsyncSinkUtil;
+import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.connector.base.sink.writer.AsyncSinkWriter;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.ElementConverter;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataResponse;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+@Slf4j
+public class CloudWatchMetricsSinkWriter<T> extends AsyncSinkWriter<T, MetricDatum> {
+
+    private final String namespace;
+    private final SdkAsyncHttpClient asyncHttpClient;
+    private final CloudWatchAsyncClient cloudWatchAsyncClient;
+
+    public CloudWatchMetricsSinkWriter(
+            String namespace,
+            Properties clientProperties,
+            ElementConverter<T, MetricDatum> elementConverter,
+            Sink.InitContext context,
+            int maxBatchSize,
+            int maxInFlightRequests,
+            int maxBufferedRequests,
+            long maxBatchSizeInBytes,
+            long maxTimeInBufferMS,
+            long maxRecordSizeInBytes,
+            Collection<BufferedRequestState<MetricDatum>> states) {
+        super(elementConverter,
+                context,
+                maxBatchSize,
+                maxInFlightRequests,
+                maxBufferedRequests,
+                maxBatchSizeInBytes,
+                maxTimeInBufferMS,
+                maxRecordSizeInBytes,
+                states);
+        this.namespace = namespace;
+
+        clientProperties.setProperty(AWSConfigConstants.HTTP_PROTOCOL_VERSION, "HTTP1_1");
+
+        asyncHttpClient = AWSGeneralUtil.createAsyncHttpClient(clientProperties);
+        cloudWatchAsyncClient = AWSAsyncSinkUtil.createAwsAsyncClient(
+                clientProperties,
+                asyncHttpClient,
+                CloudWatchAsyncClient.builder(),
+                "Apache Fink Amazon CloudWatch Metrics Sink",
+                "sink.cloudwatch.user-agent-prefix");
+    }
+
+    @Override
+    protected void submitRequestEntries(
+            List<MetricDatum> metricsToSend,
+            Consumer<List<MetricDatum>> failedMetrics) {
+
+        PutMetricDataRequest request = PutMetricDataRequest.builder()
+                .namespace(namespace)
+                .metricData(metricsToSend)
+                .build();
+
+        CompletableFuture<PutMetricDataResponse> future = cloudWatchAsyncClient.putMetricData(request);
+
+        log.debug("Sending batch of {} metrics", metricsToSend.size());
+
+        future.whenComplete((response, error) -> {
+            if (error == null) {
+                failedMetrics.accept(Collections.emptyList());
+                log.debug("Sent batch of {} metrics", metricsToSend.size());
+            } else {
+                failedMetrics.accept(metricsToSend);
+                log.warn("Failed to send batch of {} metrics", metricsToSend.size(), error);
+            }
+        });
+
+    }
+
+    @Override
+    protected long getSizeInBytes(MetricDatum metricDatum) {
+        return metricDatum.metricName().length() * 2L +
+                8L + // Double value, 8 bytes
+                8L + // Long timestamp, 8 bytes
+                metricDatum.dimensions().stream()
+                        .mapToLong(dim -> dim.name().length() * 2L + dim.value().length() * 2L)
+                        .sum();
+    }
+
+    @Override
+    public void close() {
+        asyncHttpClient.close();
+        cloudWatchAsyncClient.close();
+    }
+
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsStateSerializer.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/sink/CloudWatchMetricsStateSerializer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.sink;
+
+import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class CloudWatchMetricsStateSerializer extends AsyncSinkWriterStateSerializer<MetricDatum> {
+
+    @Override
+    protected void serializeRequestToStream(MetricDatum metricDatum, DataOutputStream dataOutputStream) throws IOException {
+        writeString(metricDatum.metricName(), dataOutputStream);
+        dataOutputStream.writeLong(metricDatum.timestamp().toEpochMilli());
+        dataOutputStream.writeDouble(metricDatum.value());
+
+        dataOutputStream.writeInt(metricDatum.dimensions().size());
+        for (Dimension dimension : metricDatum.dimensions()) {
+            writeString(dimension.name(), dataOutputStream);
+            writeString(dimension.value(), dataOutputStream);
+        }
+    }
+
+    @Override
+    protected MetricDatum deserializeRequestFromStream(long l, DataInputStream dataInputStream) throws IOException {
+        MetricDatum.Builder builder = MetricDatum.builder();
+
+        builder.metricName(readString(dataInputStream));
+        builder.timestamp(Instant.ofEpochMilli(dataInputStream.readLong()));
+        builder.value(dataInputStream.readDouble());
+
+        int dimensionCount = dataInputStream.readInt();
+        List<Dimension> dimensions = new ArrayList<>(dimensionCount);
+
+        for (int i = 0; i < dimensionCount; i++) {
+            dimensions.add(Dimension.builder()
+                    .name(readString(dataInputStream))
+                    .value(readString(dataInputStream))
+                    .build());
+        }
+
+        builder.dimensions(dimensions);
+
+        return builder.build();
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    private void writeString(final String str, final DataOutputStream dataOutputStream) throws IOException {
+        dataOutputStream.writeInt(str.length());
+        dataOutputStream.writeBytes(str);
+    }
+
+    private String readString(final DataInputStream dataInputStream) throws IOException {
+        return new String(dataInputStream.readNBytes(dataInputStream.readInt()), UTF_8);
+    }
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/DataGenSourceFunction.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/DataGenSourceFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.source;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import software.amazon.flink.example.model.OrderStats;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+@AllArgsConstructor
+public abstract class DataGenSourceFunction implements SourceFunction<OrderStats> {
+
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    private final String category;
+
+    abstract long getValue(final Instant timestamp);
+
+    @Override
+    @SneakyThrows
+    public void run(SourceContext<OrderStats> sourceContext) throws Exception {
+        Instant timestamp = Instant.now().minus(Duration.ofHours(2)).truncatedTo(SECONDS);
+
+        while (running.get()) {
+            while (Instant.now().isBefore(timestamp)) {
+                Thread.sleep(1000);
+            }
+
+            sourceContext.collect(OrderStats.builder()
+                    .count(getValue(timestamp))
+                    .timestamp(timestamp)
+                    .category(category)
+                    .build());
+
+            timestamp = timestamp.plus(Duration.ofSeconds(1));
+        }
+    }
+
+    @Override
+    public void cancel() {
+        running.set(false);
+    }
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/SawToothSourceFunction.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/SawToothSourceFunction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.source;
+
+import java.time.Instant;
+
+public class SawToothSourceFunction extends DataGenSourceFunction {
+
+    private static final long PERIOD = 60 * 60 * 1000;
+
+    public SawToothSourceFunction(final String category) {
+        super(category);
+    }
+
+    @Override
+    long getValue(Instant timestamp) {
+        long y = timestamp.toEpochMilli() % PERIOD;
+        return (long) (100D / PERIOD * y);
+    }
+
+}

--- a/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/SineSourceFunction.java
+++ b/cloudwatch-async-sink-example/src/main/java/software/amazon/flink/example/source/SineSourceFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.source;
+
+import java.time.Instant;
+
+public class SineSourceFunction extends DataGenSourceFunction {
+
+    private static final long PERIOD = 60 * 60 * 1000;
+    private static final long SCALE = 50;
+    private static final double TWO_PI = Math.PI * 2;
+
+    public SineSourceFunction(final String category) {
+        super(category);
+    }
+
+    @Override
+    long getValue(Instant timestamp) {
+        double radians = TWO_PI / PERIOD * (timestamp.toEpochMilli() % PERIOD);
+        double y = Math.sin(radians) * SCALE + SCALE;
+        return (long) y;
+    }
+
+}

--- a/cloudwatch-async-sink-example/src/main/resources/logback.xml
+++ b/cloudwatch-async-sink-example/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+  -->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{36} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/cloudwatch-async-sink-example/src/test/java/software/amazon/flink/example/sink/CloudWatchMetricsStateSerializerTest.java
+++ b/cloudwatch-async-sink-example/src/test/java/software/amazon/flink/example/sink/CloudWatchMetricsStateSerializerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.flink.example.sink;
+
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+class CloudWatchMetricsStateSerializerTest {
+
+    @Test
+    void serializeAndDeserialize() throws Exception {
+        MetricDatum expected = MetricDatum.builder()
+                .metricName("metric-name")
+                .timestamp(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+                .value(12345D)
+                .dimensions(
+                        Dimension.builder()
+                                .name("dim-1")
+                                .value("val-1")
+                                .build(),
+                        Dimension.builder()
+                                .name("dim-2")
+                                .value("val-2")
+                                .build())
+                .build();
+
+        CloudWatchMetricsStateSerializer serializer = new CloudWatchMetricsStateSerializer();
+
+        BufferedRequestState<MetricDatum> requestState = new BufferedRequestState<MetricDatum>(
+                Collections.singletonList(new RequestEntryWrapper(expected, 10000)));
+
+        MetricDatum actual = serializer
+                .deserialize(1, serializer.serialize(requestState))
+                .getBufferedRequestEntries()
+                .get(0)
+                .getRequestEntry();
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+
+}


### PR DESCRIPTION
*Description of changes:*
- Added a sample project that builds a CloudWatch metrics sink using the Async Sink framework for Apache Flink 1.15


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
